### PR TITLE
Fix HTTP request error handling

### DIFF
--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -46,16 +46,19 @@ bool HttpClientWrapper::performRequest(const char* method, const char* path,
   
   Utils::feedWatchdog();
   
-  // Start request
+  // Start request and capture the return code from the HTTP library.
+  // The previous implementation ignored the value returned by the
+  // request methods which meant connection failures were never
+  // reported correctly and `err` always stayed at 0.
   int err = 0;
-  
+
   if (strcmp(method, "GET") == 0) {
     http->beginRequest();
-    http->get(fullPath);
+    err = http->get(fullPath);
     http->endRequest();
   } else if (strcmp(method, "POST") == 0 && payload) {
     http->beginRequest();
-    http->post(fullPath);
+    err = http->post(fullPath);
     http->sendHeader("Content-Type", "application/json");
     http->sendHeader("Content-Length", String(payload->length()));
     http->beginBody();
@@ -63,7 +66,7 @@ bool HttpClientWrapper::performRequest(const char* method, const char* path,
     http->endRequest();
   } else if (strcmp(method, "PATCH") == 0 && payload) {
     http->beginRequest();
-    http->patch(fullPath);
+    err = http->patch(fullPath);
     http->sendHeader("Content-Type", "application/json");
     http->sendHeader("Content-Length", String(payload->length()));
     http->beginBody();


### PR DESCRIPTION
## Summary
- ensure HttpClient captures return codes from request calls

## Testing
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68430b021dc08331b8daa788a0238db3
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed HTTP client so it now captures and reports errors from request calls instead of ignoring them.

- **Bug Fixes**
  - Updated GET, POST, and PATCH methods to store the return code from the HTTP library.

<!-- End of auto-generated description by cubic. -->

