### PR TITLE
Improve HTTP error logging

### DIFF
--- a/src/HttpClient.cpp
+++ b/src/HttpClient.cpp
@@ -91,9 +91,14 @@ bool HttpClientWrapper::performRequest(const char* method, const char* path,
            statusCode,
            (statusCode >= 200 && statusCode < 300) ? "SUCCESS" : "ERROR",
            response.length());
-  
-  if (response.length() > 0 && response.length() < 200) {
-    LOG_DEBUG(MODULE_HTTP, "Response body: %s", response.c_str());
+
+  if (response.length() > 0) {
+    if (response.length() <= 200) {
+      LOG_DEBUG(MODULE_HTTP, "Response body: %s", response.c_str());
+    } else {
+      String truncated = response.substring(0, 200);
+      LOG_DEBUG(MODULE_HTTP, "Response body (truncated): %s", truncated.c_str());
+    }
   }
   
   // Close connection


### PR DESCRIPTION
## Summary
- improve debug log output when server returns error response

## Testing
- `platformio run -e esp32dev` *(fails: `platformio: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684a418e9e1083318fbe14e1e69cded6
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved HTTP error logging by showing the full response body for short responses and a truncated version for longer ones. This makes it easier to debug server errors.

<!-- End of auto-generated description by cubic. -->

